### PR TITLE
BUILD-5928 Setup releasability checks and update pre-commit checks

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -1,0 +1,21 @@
+name: Releasability status
+on:
+  check_suite:
+    types:
+      - completed
+jobs:
+  update_releasability_status:
+    runs-on: ubuntu-24.04
+    name: Releasability status
+    permissions:
+      id-token: write
+      statuses: write
+      contents: read
+    if: >-
+      (contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-'))
+      && github.event.check_suite.conclusion == 'success'
+      && github.event.check_suite.app.slug == 'cirrus-ci'
+    steps:
+      - uses: SonarSource/gh-action_releasability/releasability-status@3b4cd825239b4b793482f9a7319bc465e0fa0891 # 2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -1,0 +1,13 @@
+---
+name: Slack Notifications
+on:
+ check_run:
+  types: [rerequested, completed]
+
+jobs:
+ slack-notifications:
+  permissions:
+   id-token: write  # to authenticate via OIDC
+  uses: SonarSource/gh-action_build-notify/.github/workflows/main.yaml@2cb5529bb79683d97394f19834361a1c283d4f9f # 1.1.0
+  with:
+   slackChannel: squad-dev-infra-github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,18 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: 5341f388c2a962d3bc66e075f00b80ab45b15f24 # v0.1.20
+    rev: d0bcdb35c6999a4a120b528f050d2b11778fd3d0 # v0.1.23
     hooks:
       - id: shellcheck
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 32ee411cf36142e6082f10870ae62172ce9af133 # 35.32.0
+    rev: 4a2fbe3c2f8e5831b4967bbb32ce80abf5381815 # 38.114.0
     hooks:
       - id: renovate-config-validator
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 20447075e31543a8b125f2df18d75f3b5e7d4d2e # 0.22.0
+    rev: b4235fda059c7c36722a3f8c4b71c45a0826a8b7 # 0.29.3
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: c9ea83146232fb263effdfe6f222d87f5395b27a # v0.39.0
+    rev: aa975a18c9a869648007d33864034dbc7481fe5e # v0.42.0
     hooks:
       - id: markdownlint


### PR DESCRIPTION
## Changes

- [x] Add releasability GitHub workflow
- [x] Update pre-commit checks versions - That way we benefit from up to date checks

## How was it tested?

- [x] Pre-commit CI workflow is green https://github.com/SonarSource/sonar-dummy-js/actions/runs/11254248862/job/31291238882?pr=46
- [x] Can we test releasability checks in a PR? 