### PR TITLE
Revert "BUILD-7112 test gh-action_releasability"

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -19,6 +19,6 @@ jobs:
       github.event.check_suite.conclusion == 'success' &&
       github.event.check_suite.app.slug == 'cirrus-ci'
     steps:
-      - uses: SonarSource/gh-action_releasability/releasability-status@fix/jcarsique/BUILD-7112-pendingStatus
+      - uses: SonarSource/gh-action_releasability/releasability-status@3b4cd825239b4b793482f9a7319bc465e0fa0891 # 2.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 35be788010a39754c05079103b7ffc0e54e4ab5c.
