### PR TITLE
BUILD-8605 Update mise-action SHA to v2.4.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2025.7.12
       - id: get-build-number


### PR DESCRIPTION
This PR updates `jdx/mise-action` SHA from v2.4.0 to v2.4.4 while keeping the `mise` version at `2025.7.12`.