### PR TITLE
BUILD-9161 test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Build, Test, Analyze and deploy
         id: build
         uses: SonarSource/ci-github-actions/build-npm@master # dogfood
+        env:
+          SQ_SCANNER_VERSION: 4.3.0 # 4.3.1 requires node>=20
         with:
           artifactory-deploy-repo: "sonarsource-npm-public-qa"
           deploy-pull-request: true


### PR DESCRIPTION
Depends on https://github.com/SonarSource/ci-github-actions/pull/102

- Add an example of calling custom NPM commands after call to `config-npm`, as an alternative or complement to `build-npm`.
- Upgrade actions/checkout to v5.0.0
- Move concurrency definition to the top
