### PR TITLE
BUILD-10765 Important: Update SonarSource/gh-action_release to v6 and gh-action_releasability to v3

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -19,6 +19,6 @@ jobs:
       contents: read
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: SonarSource/gh-action_releasability/releasability-status@master # dogfood
+      - uses: SonarSource/gh-action_releasability/releasability-status@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release:
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@d9afbb6f48da6012ebf64d8247d7b44995c7cace # 6.7.0
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       publishToNpmJS: true
       skipJavascriptReleasabilityChecks: true


### PR DESCRIPTION
**Important:** Update GitHub Actions to compliant versions.

- `.github/workflows/release.yml`: `release` `d9afbb6f48da6012ebf64d8247d7b44995c7cace` → `v6`
- `.github/workflows/releasability.yml`: `releasability` `master` → `v3`

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-31-04-2026/23899