### PR TITLE
Add StepSecurity Harden Runner to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
     outputs:
       BUILD_NUMBER: ${{ steps.build.outputs.BUILD_NUMBER }}
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
@@ -52,6 +55,9 @@ jobs:
       id-token: write
       contents: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
@@ -80,4 +86,7 @@ jobs:
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.BUILD_NUMBER }} # reuse BUILD_NUMBER from build job
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: SonarSource/ci-github-actions/promote@master # dogfood

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,9 @@ jobs:
     name: "pre-commit"
     runs-on: github-ubuntu-latest-s
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: SonarSource/gh-action_pre-commit@0ecedc4e4070444a95f6b6714ddc3ebcdde697c4 # 1.1.0
         with:
           extra-args: >

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -19,6 +19,9 @@ jobs:
       contents: read
     if: github.event.workflow_run.conclusion == 'success'
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: SonarSource/gh-action_releasability/releasability-status@master # dogfood
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -15,6 +15,9 @@ jobs:
       contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
     runs-on: github-ubuntu-latest-s
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - name: Send Slack Notification
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create dummy cache content
         run: mkdir -p ~/.npm && echo "migration-test-${{ github.run_id }}" > ~/.npm/test-file.txt
@@ -36,6 +39,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache with migration fallback
         id: cache
@@ -60,6 +66,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache without migration fallback
         id: cache
@@ -85,6 +94,9 @@ jobs:
     env:
       CACHE_IMPORT_GITHUB: 'false'
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache without migration fallback (via env)
         id: cache

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -16,6 +16,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: SonarSource/ci-github-actions/build-npm@master # dogfood
         with:


### PR DESCRIPTION
Adds [`step-security/harden-runner@v2`](https://github.com/step-security/harden-runner) as the first step in every job across all workflow files, using `egress-policy: audit` to monitor outbound network traffic without blocking.

**Workflows updated:** `build.yml`, `pre-commit.yml`, `releasability.yml`, `slack_notify.yml`, `test-cache-migration-gh2s3.yml`, `unified-dogfooding.yml`

> `release.yml` is excluded as its job uses a reusable workflow call (`uses:`) and does not support injecting steps.