### PR TITLE
BUILD-11686 Add report-ci-metrics job to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,19 @@ jobs:
           npm install
           npm test
 
+  report-ci-metrics:
+    needs:
+      - build
+      - custom-command
+    if: always() && (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: sonar-xs
+    name: Report CI metrics
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: SonarSource/ci-github-actions/report-ci-metrics@master # dogfood
+
   promote:
     needs:
       - build


### PR DESCRIPTION
## What

Add a `report-ci-metrics` job to `build.yml`, mirroring the one in [sonar-dummy](https://github.com/SonarSource/sonar-dummy/blob/master/.github/workflows/build.yml). It runs after the `build` and `custom-command` jobs (`if: always()`) and posts the CI-metrics sticky PR comment / job summary via `SonarSource/ci-github-actions/report-ci-metrics@master`.

## Why

Roll out CI-metrics dogfooding to this repo now that `report-ci-metrics` trend-display ([BUILD-11311](https://sonarsource.atlassian.net/browse/BUILD-11311)) is merged to `ci-github-actions` master and [gh-action_cache PR #87](https://github.com/SonarSource/gh-action_cache/pull/87) (BUILD-11686) fixed the cache dist to emit the snake_case JSON keys the report consumes.

The action reads per-job metrics from the run's job logs via the GitHub API — no checkout, artifacts, or cache step needed; only `actions: read` + `pull-requests: write`.

## Verification

- `actionlint` clean (the `github-ubuntu-latest-s` custom-runner notices are pre-existing and apply to every job; the new job reuses the same label).
- `needs: [build, custom-command]` matches existing job keys.

Part of BUILD-11686

[BUILD-11311]: https://sonarsource.atlassian.net/browse/BUILD-11311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ