### PR TITLE
BUILD-11789 Fix quality gate: npm audit fix for js-yaml SCA CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3139,9 +3139,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Run `npm audit fix` to resolve js-yaml and related transitive CVEs
- Target: clear `sca_severity_vulnerability` quality gate (score 15 > threshold 14)

## Test plan
- [ ] CI passes
- [ ] SonarQube quality gate passes on PR analysis