### PR TITLE
BUILD-11886 pin Java 21 via mise to satisfy scanner plugin requirement

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 node = "18"
+java = "temurin-21"


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/BUILD-11886

## Problem

The `master` Build workflow fails on the SonarScanner Analyze step with:

```
java.lang.IllegalStateException: The plugin [architecturejavascriptfrontend] does not support Java 17.0.19
Caused by: java.lang.UnsupportedClassVersionError: ... compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
```

Class file version 65.0 = Java 21. The runner's default JRE is 17.0.19, and `sonar.scanner.skipJreProvisioning=true` (set in BUILD-7099 for ARM image compatibility) prevents the scanner from auto-provisioning a compatible JRE.

## Fix

Pin `java = "temurin-21"` in `mise.toml`, consistent with how `node` is already pinned there. This keeps `skipJreProvisioning=true` intact and gives the scanner an explicit, reproducible JVM instead of relying on the runner's default.

## Test plan

- [ ] CI Build workflow passes (SonarScanner analyze step succeeds)