### PR TITLE
BUILD-11887 add missing gh-action-lt-backlog workflows

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -1,0 +1,30 @@
+---
+name: Pull Request Closed
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  PullRequestClosed_job:
+    name: Pull Request Closed
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+      pull-requests: read
+    # For external PR, ticket should be moved manually
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+        with:
+          secrets: |
+            development/kv/data/jira user | JIRA_USER;
+            development/kv/data/jira token | JIRA_TOKEN;
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
+        with:
+          github-token: ${{ github.token }}
+          jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          is-eng-xp-squad: true

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -1,0 +1,33 @@
+---
+name: Pull Request Created
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  PullRequestCreated_job:
+    name: Pull Request Created
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+    # For external PR, ticket should be created manually
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
+            development/kv/data/jira user | JIRA_USER;
+            development/kv/data/jira token | JIRA_TOKEN;
+            development/kv/data/rootly ro-api-key | ROOTLY_TOKEN;
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestCreated@v2
+        with:
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+          jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          rootly-token: ${{ fromJSON(steps.secrets.outputs.vault).ROOTLY_TOKEN }}
+          is-eng-xp-squad: true
+          team-review-component: EngXP Internal Tooling

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -1,0 +1,32 @@
+---
+name: Request review
+
+on:
+  pull_request:
+    types:
+      - review_requested
+
+jobs:
+  RequestReview_job:
+    name: Request review
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+    # For external PR, ticket should be moved manually
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
+            development/kv/data/jira user | JIRA_USER;
+            development/kv/data/jira token | JIRA_TOKEN;
+            development/kv/data/rootly ro-api-key | ROOTLY_TOKEN;
+      - uses: sonarsource/gh-action-lt-backlog/RequestReview@v2
+        with:
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+          jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          rootly-token: ${{ fromJSON(steps.secrets.outputs.vault).ROOTLY_TOKEN }}
+          is-eng-xp-squad: true

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -1,0 +1,34 @@
+---
+name: Submit Review
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  SubmitReview_job:
+    name: Submit Review
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+      pull-requests: read
+    # For external PR, ticket should be moved manually
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && (github.event.review.state == 'changes_requested'
+          || github.event.review.state == 'approved')
+    steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
+            development/kv/data/jira user | JIRA_USER;
+            development/kv/data/jira token | JIRA_TOKEN;
+      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@v2
+        with:
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+          jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          is-eng-xp-squad: true


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/BUILD-11887

## Problem

sonar-dummy-js is missing the standard `sonarsource/gh-action-lt-backlog` workflows that other dummy repositories already have (sonar-dummy, sonar-dummy-maven, sonar-dummy-yarn, sonar-dummy-gradle-oss, sonar-dummy-python-oss):

- `PullRequestCreated.yml`
- `PullRequestClosed.yml`
- `RequestReview.yml`
- `SubmitReview.yml`

Without these, opening/closing PRs and requesting/submitting reviews on this repo does not automatically create or move the corresponding Jira ticket in the backlog — this is what caused BUILD-11886's PR (#144) to need a manually-created ticket.

## Fix

Add the four workflow files, mirrored verbatim from the sibling dummy repos.

## Test plan

- [ ] Open a test PR and confirm a Jira ticket is created / title updated
- [ ] Close/merge the PR and confirm the ticket transitions
- [ ] Request a review and confirm the ticket updates