### PR TITLE
PREQ-7781 Bump contents: read to contents: write on unified-dogfooding

### DIFF
--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and run shadow scans
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: SonarSource/ci-github-actions/build-npm@master # dogfood


### PR DESCRIPTION
## Why

`unified-dogfooding.yml`'s build job calls an action that calls `get-build-number` internally,
which now requires `contents: write` to claim a number
([SonarSource/ci-github-actions#336](https://github.com/SonarSource/ci-github-actions/pull/336),
merged). This job has been hard-failing with a 403 on every run since the merge:

```
{"message":"Resource not accessible by integration",...,"status":"403"}
This action requires 'contents: write' in the calling workflow's permissions (contents: read is no longer sufficient).
```

## Fix

Bump `contents: read` to `contents: write` on the job's permissions.