### PR TITLE
PREQ-7781 Drop the now-dead BUILD_NUMBER passthrough

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
       id-token: write
       contents: write
       attestations: write
-    outputs:
-      BUILD_NUMBER: ${{ steps.build.outputs.BUILD_NUMBER }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -90,7 +88,5 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    env:
-      BUILD_NUMBER: ${{ needs.build.outputs.BUILD_NUMBER }} # reuse BUILD_NUMBER from build job
     steps:
       - uses: SonarSource/ci-github-actions/promote@master # dogfood


### PR DESCRIPTION
## Why

`build`'s own `BUILD_NUMBER` output and `promote`'s `env` passthrough of it were leftover from
before [SonarSource/ci-github-actions#336](https://github.com/SonarSource/ci-github-actions/pull/336),
where cross-job reuse needed explicit wiring. Cross-job reuse is now automatic
(`refs/build-runs/<run_id>/<N>`) - `promote` calls an action that calls `get-build-number`
internally and reuses `build`'s claim on its own, regardless of this passthrough.

Missed when `contents: write` was bumped in [#147](https://github.com/SonarSource/sonar-dummy-js/pull/147)
(that PR only touched `unified-dogfooding.yml`).

## Fix

Remove the dead `outputs`/`env` `BUILD_NUMBER` wiring from `build` and `promote`.