### PR TITLE
BUILD-12406 / BUILD-12407 Migrate off deprecated runner, run actionlint in pre-commit, fix npm Repox routing

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Configuration for https://github.com/rhysd/actionlint run by pre-commit
+self-hosted-runner:
+  labels:
+    - sonar-s
+    - sonar-xs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     name: Build
     permissions:
       id-token: write
@@ -44,7 +44,7 @@ jobs:
   custom-command:
     needs:
       - build
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     name: Custom NPM command
     permissions:
       id-token: write
@@ -83,7 +83,7 @@ jobs:
   promote:
     needs:
       - build
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     name: Promote
     permissions:
       id-token: write

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,8 +5,15 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
+    permissions:
+      id-token: write
+      contents: write
     runs-on: sonar-s
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: SonarSource/ci-github-actions/config-npm@master # dogfood
       - uses: SonarSource/gh-action_pre-commit@0ecedc4e4070444a95f6b6714ddc3ebcdde697c4 # 1.1.0
         with:
           extra-args: >

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     steps:
       - uses: SonarSource/gh-action_pre-commit@0ecedc4e4070444a95f6b6714ddc3ebcdde697c4 # 1.1.0
         with:

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   releasability-status:
     name: Releasability status
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     permissions:
       id-token: write
       statuses: write

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -13,7 +13,7 @@ jobs:
   slack-notifications:
     if: >-
       contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     steps:
       - name: Send Slack Notification
         env:

--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   # Prerequisite: provision a GitHub cache entry to be imported by scenario 1
   provision-github-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     name: "Provision GitHub cache entry"
     permissions:
       contents: read
@@ -30,7 +30,7 @@ jobs:
   # Scenario 1: S3 backend with import mode active (default behavior after migration begins)
   test-s3-import-enabled:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     name: "S3 + import enabled (migration fallback)"
     permissions:
       id-token: write
@@ -54,7 +54,7 @@ jobs:
   # Scenario 2: S3 backend with import mode explicitly disabled
   test-s3-import-disabled:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     name: "S3 + import disabled (migration complete)"
     permissions:
       id-token: write
@@ -77,7 +77,7 @@ jobs:
   # Scenario 3: S3 backend with import disabled via env var (repo variable pattern)
   test-s3-import-disabled-via-env:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     name: "S3 + import disabled via env var"
     permissions:
       id-token: write

--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CACHE_BACKEND: s3   # forces S3 for all cache steps, including those in reusable actions
+  CACHE_TEST_DIR: ${{ github.workspace }}/.cache-migration-test
 
 jobs:
   # Prerequisite: provision a GitHub cache entry to be imported by scenario 1
@@ -20,11 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Create dummy cache content
-        run: mkdir -p ~/.npm && echo "migration-test-${{ github.run_id }}" > ~/.npm/test-file.txt
+        run: mkdir -p "$CACHE_TEST_DIR" && echo "migration-test-${{ github.run_id }}" > "$CACHE_TEST_DIR/test-file.txt"
       - name: Save to GitHub cache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.npm
+          path: ${{ env.CACHE_TEST_DIR }}
           key: test-migration-${{ runner.os }}-${{ github.run_id }}
 
   # Scenario 1: S3 backend with import mode active (default behavior after migration begins)
@@ -41,15 +42,15 @@ jobs:
         id: cache
         uses: SonarSource/gh-action_cache@master # dogfood
         with:
-          path: ~/.npm
+          path: ${{ env.CACHE_TEST_DIR }}
           key: test-migration-${{ runner.os }}-${{ github.run_id }}
           backend: s3
           # import-github-cache defaults to true — no need to set it explicitly
       - name: Verify import succeeded
         run: |
           [[ "${{ steps.cache.outputs.cache-hit }}" == "true" ]] || { echo "ERROR: cache-hit is not true"; exit 1; }
-          test -f ~/.npm/test-file.txt || { echo "ERROR: cache content not restored from GitHub"; exit 1; }
-          rm -rf ~/.npm  # prevent saving to S3 so other scenarios don't find it
+          test -f "$CACHE_TEST_DIR/test-file.txt" || { echo "ERROR: cache content not restored from GitHub"; exit 1; }
+          rm -rf "$CACHE_TEST_DIR"  # prevent saving to S3 so other scenarios don't find it
 
   # Scenario 2: S3 backend with import mode explicitly disabled
   test-s3-import-disabled:
@@ -65,14 +66,14 @@ jobs:
         id: cache
         uses: SonarSource/gh-action_cache@master # dogfood
         with:
-          path: ~/.npm
+          path: ${{ env.CACHE_TEST_DIR }}
           key: test-migration-${{ runner.os }}-${{ github.run_id }}
           backend: s3
           import-github-cache: 'false'
       - name: Verify no import from GitHub
         run: |
           [[ "${{ steps.cache.outputs.cache-hit }}" != "true" ]] || { echo "ERROR: cache-hit is true but import should be disabled"; exit 1; }
-          test ! -f ~/.npm/test-file.txt || { echo "ERROR: cache content was restored but import should be disabled"; exit 1; }
+          test ! -f "$CACHE_TEST_DIR/test-file.txt" || { echo "ERROR: cache content was restored but import should be disabled"; exit 1; }
 
   # Scenario 3: S3 backend with import disabled via env var (repo variable pattern)
   test-s3-import-disabled-via-env:
@@ -90,10 +91,10 @@ jobs:
         id: cache
         uses: SonarSource/gh-action_cache@master # dogfood
         with:
-          path: ~/.npm
+          path: ${{ env.CACHE_TEST_DIR }}
           key: test-migration-${{ runner.os }}-${{ github.run_id }}
           backend: s3
       - name: Verify no import from GitHub
         run: |
           [[ "${{ steps.cache.outputs.cache-hit }}" != "true" ]] || { echo "ERROR: cache-hit is true but import should be disabled"; exit 1; }
-          test ! -f ~/.npm/test-file.txt || { echo "ERROR: cache content was restored but import should be disabled"; exit 1; }
+          test ! -f "$CACHE_TEST_DIR/test-file.txt" || { echo "ERROR: cache content was restored but import should be disabled"; exit 1; }

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-s
     name: Build and run shadow scans
     permissions:
       id-token: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,10 @@ repos:
     rev: 40f924cd642f5dc98d12bd97b07f3752223553da  # frozen: v0.1.30
     hooks:
       - id: shellcheck
+  - repo: https://github.com/rhysd/actionlint
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
+    hooks:
+      - id: actionlint
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 8e756eb1aa6a741a2c80b37e0795c7c29104fa6d  # frozen: 43.239.0
     hooks:


### PR DESCRIPTION
## Why

`github-ubuntu-latest-s` is deprecated for first-party CI (deadline **2026-08-31**) - see
[GitHub Actions Runners - GitHub](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/GitHub+Actions+Runners+-+GitHub).
None of these jobs are peachee/external-corpus analysis (the only carve-out) or use Docker, so
`sonar-s` is a safe, same-size (4 vCPU / 16 GB) direct replacement.

## Fix

- `pre-commit.yml`, `build.yml`, `test-cache-migration-gh2s3.yml`, `slack_notify.yml`,
  `releasability.yml`, `unified-dogfooding.yml`: `github-ubuntu-latest-s` → `sonar-s`.
- New `.github/actionlint.yaml` declaring the self-hosted-runner labels actually used here (this
  repo had no such config before, so actionlint flagged every custom label as unknown).

## Also in this PR (BUILD-12406, BUILD-12407)

Bundled in rather than opening yet more PRs on this repo, since both are closely related to the
`.github/actionlint.yaml` work above:

- **BUILD-12406**: this repo never actually ran `actionlint` in pre-commit, so the new
  `.github/actionlint.yaml` had nothing consuming it. Added the `rhysd/actionlint` hook to
  `.pre-commit-config.yaml` — pre-commit provisions its own Go toolchain for it automatically, no
  system Go or extra CI step required.
- **BUILD-12407**: fixed a separate, pre-existing bug this hook install exposed — the pre-commit
  job never routed npm through Repox, so a fresh `npm install` from this self-hosted runner hit
  the public registry directly and failed TLS verification. Added `config-npm`, matching
  sonar-dummy-yarn's already-working setup.